### PR TITLE
Fix misleading information

### DIFF
--- a/content/docs/look-and-feel/enable-dark-mode-only/index.en.md
+++ b/content/docs/look-and-feel/enable-dark-mode-only/index.en.md
@@ -33,8 +33,7 @@ See [replace meta module]({{< relref "blog/replace-meta-modules" >}}) if you're 
 The `hb.color` is available since `github.com/hbstack/hb@v0.9.0`, please make sure you've upgraded to the latest version.
 {{% /bs/alert%}}
 
-{{< bs/config-toggle filename=hugo title="Site Parameters" >}}
-params:
-  hb:
-    color: dark
+{{< bs/config-toggle filename=params title="Site Parameters" >}}
+hb:
+  color: dark
 {{< /bs/config-toggle >}}

--- a/content/docs/look-and-feel/enable-dark-mode-only/index.en.md
+++ b/content/docs/look-and-feel/enable-dark-mode-only/index.en.md
@@ -34,6 +34,7 @@ The `hb.color` is available since `github.com/hbstack/hb@v0.9.0`, please make su
 {{% /bs/alert%}}
 
 {{< bs/config-toggle filename=hugo title="Site Parameters" >}}
-hb:
-  color: dark
+params:
+  hb:
+    color: dark
 {{< /bs/config-toggle >}}

--- a/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hans.md
+++ b/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hans.md
@@ -34,6 +34,7 @@ authors:
 {{% /bs/alert%}}
 
 {{< bs/config-toggle filename=hugo title="站点参数" >}}
-hb:
-  color: dark
+params:
+  hb:
+    color: dark
 {{< /bs/config-toggle >}}

--- a/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hans.md
+++ b/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hans.md
@@ -33,8 +33,7 @@ authors:
 `hb.color` 自 `github.com/hbstack/hb@v0.9.0` 可用，请确保你已升级到最新版本。
 {{% /bs/alert%}}
 
-{{< bs/config-toggle filename=hugo title="站点参数" >}}
-params:
-  hb:
-    color: dark
+{{< bs/config-toggle filename=params title="站点参数" >}}
+hb:
+  color: dark
 {{< /bs/config-toggle >}}

--- a/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hant.md
+++ b/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hant.md
@@ -33,8 +33,7 @@ authors:
 `hb.color` 自 `github.com/hbstack/hb@v0.9.0` 可用，請確保你已升級到最新版本。
 {{% /bs/alert%}}
 
-{{< bs/config-toggle filename=hugo title="站點參數" >}}
-params:
-  hb:
-    color: dark
+{{< bs/config-toggle filename=params title="站點參數" >}}
+hb:
+  color: dark
 {{< /bs/config-toggle >}}

--- a/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hant.md
+++ b/content/docs/look-and-feel/enable-dark-mode-only/index.zh-hant.md
@@ -34,6 +34,7 @@ authors:
 {{% /bs/alert%}}
 
 {{< bs/config-toggle filename=hugo title="站點參數" >}}
-hb:
-  color: dark
+params:
+  hb:
+    color: dark
 {{< /bs/config-toggle >}}


### PR DESCRIPTION
It should be `params.yaml` rather than `hugo.yaml`. Or, `params:` should be put as parent node.